### PR TITLE
DRAFT: Scribble support thus far

### DIFF
--- a/packages/flutter/lib/src/material/text_field.dart
+++ b/packages/flutter/lib/src/material/text_field.dart
@@ -1051,7 +1051,7 @@ class _TextFieldState extends State<TextField> with RestorationMixin implements 
     if (!_isEnabled)
       return false;
 
-    if (cause == SelectionChangedCause.longPress)
+    if (cause == SelectionChangedCause.longPress || cause == SelectionChangedCause.scribble)
       return true;
 
     if (_effectiveController.text.isNotEmpty)

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -850,6 +850,7 @@ class RenderEditable extends RenderBox with RelayoutWhenSystemFontsChangeMixin {
   /// The text to display.
   TextSpan? get text => _textPainter.text as TextSpan?;
   final TextPainter _textPainter;
+  TextPainter? get textPainter => _textPainter;
   set text(TextSpan? value) {
     if (_textPainter.text == value)
       return;

--- a/packages/flutter/lib/src/rendering/editable.dart
+++ b/packages/flutter/lib/src/rendering/editable.dart
@@ -61,6 +61,9 @@ enum SelectionChangedCause {
   /// The user used the mouse to change the selection by dragging over a piece
   /// of text.
   drag,
+
+  /// The user iPadOS 14 Scribble to change the selection.
+  scribble,
 }
 
 /// Signature for the callback that reports when the caret location changes.

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -931,9 +931,7 @@ class TextInputConnection {
   List cachedTextBoxes = [];
 
   void setSelectionRects(List textBoxes) {
-    var equal = cachedTextBoxes.length == textBoxes.length &&
-        List.generate(textBoxes.length, (i) => textBoxes[i] == cachedTextBoxes[i]).reduce((a, b) => a && b);
-    if (!equal) {
+    if (!listEquals(cachedTextBoxes, textBoxes)) {
       cachedTextBoxes = textBoxes;
       TextInput._instance._setSelectionRects(textBoxes.map((box) {
         var rect = box.toRect();

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -909,6 +909,20 @@ class TextInputConnection {
     }
   }
 
+  List cachedTextBoxes = [];
+
+  void setSelectionRects(List textBoxes) {
+    var equal = cachedTextBoxes.length == textBoxes.length &&
+        List.generate(textBoxes.length, (i) => textBoxes[i] == cachedTextBoxes[i]).reduce((a, b) => a && b);
+    if (!equal) {
+      cachedTextBoxes = textBoxes;
+      TextInput._instance._setSelectionRects(textBoxes.map((box) {
+        var rect = box.toRect();
+        return <double>[rect.left, rect.top, rect.width, rect.height];
+      }).toList());
+    }
+  }
+
   /// Send text styling information.
   ///
   /// This information is used by the Flutter Web Engine to change the style
@@ -1230,6 +1244,13 @@ class TextInput {
   void _setEditableSizeAndTransform(Map<String, dynamic> args) {
     _channel.invokeMethod<void>(
       'TextInput.setEditableSizeAndTransform',
+      args,
+    );
+  }
+
+  void _setSelectionRects(List<List<double>> args) {
+    _channel.invokeMethod<void>(
+      'TextInput.setSelectionRects',
       args,
     );
   }

--- a/packages/flutter/lib/src/services/text_input.dart
+++ b/packages/flutter/lib/src/services/text_input.dart
@@ -1181,6 +1181,7 @@ class TextInput {
     }
 
     final List<dynamic> args = methodCall.arguments as List<dynamic>;
+    print('[scribble][flutter] $method: $args');
 
     if (method == 'TextInputClient.updateEditingStateWithTag') {
       final TextInputClient client = _currentConnection!._client;

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -1655,7 +1655,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       return;
     } else if (value.text == _value.text && value.composing == _value.composing && value.selection != _value.selection) {
       // `selection` is the only change.
-      _handleSelectionChanged(value.selection, renderEditable, SelectionChangedCause.keyboard);
+      _handleSelectionChanged(value.selection, renderEditable, value.scribbleInProgress ? SelectionChangedCause.scribble : SelectionChangedCause.keyboard);
     } else {
       _formatAndSetValue(value);
     }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2282,6 +2282,10 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       final Size size = renderEditable.size;
       final Matrix4 transform = renderEditable.getTransformTo(null);
       _textInputConnection.setEditableSizeAndTransform(size, transform);
+      var textSpan = buildTextSpan();
+      var rects = List.generate(
+          textSpan.text.length, (i) => renderEditable.textPainter.getBoxesForSelection(TextSelection(baseOffset: i, extentOffset: i + 1)).first);
+      _textInputConnection.setSelectionRects(rects);
       SchedulerBinding.instance
           .addPostFrameCallback((Duration _) => _updateSizeAndTransform());
     }

--- a/packages/flutter/lib/src/widgets/editable_text.dart
+++ b/packages/flutter/lib/src/widgets/editable_text.dart
@@ -2314,6 +2314,7 @@ class EditableTextState extends State<EditableText> with AutomaticKeepAliveClien
       TextInput.registerScribbleElement(_elementIdentifier, [rect.left, rect.top, rect.width, rect.height], (x, y) {
         print('[scribble][flutter] focusCallback for $_elementIdentifier');
         widget.focusNode.requestFocus();
+        renderEditable.selectPositionAt(from: Offset(x, y), cause: SelectionChangedCause.keyboard);
       });
     }
     WidgetsBinding.instance.addPostFrameCallback((_) { _updateScribbleRect(); });


### PR DESCRIPTION
### Description

Implementing the framework side of Scribble support. So far, this sends the selection boxes for the currently focused input over the `TextInputConnection` and adds `SelectionChangedCause.scribble` and `TextInputClient.showToolbar()` to support showing the selection handles and toolbar when scribble is used to select text.

### Related Issues

- https://github.com/flutter/flutter/issues/61278